### PR TITLE
feat(ui): 招聘端配置管理 — 完整导出 / 选择性原子导入

### DIFF
--- a/docs/superpowers/specs/2026-05-12-recruiter-config-export-import-design.md
+++ b/docs/superpowers/specs/2026-05-12-recruiter-config-export-import-design.md
@@ -1,0 +1,174 @@
+# 招聘端配置导出/导入功能设计
+
+**日期：** 2026-05-12  
+**状态：** 待实现
+
+## 背景
+
+用户需要将招聘端的完整配置交接给同事，现有系统只有 per-rubric 的 JSON 导入，没有全局配置导出/导入能力。
+
+## 目标
+
+在左导航"集成与工具"下新增"配置管理"入口，支持将所有招聘端配置导出为单个 JSON 文件，并支持选择性原子导入。
+
+---
+
+## Bundle 文件格式
+
+文件扩展名：`.json`，默认命名 `geekgeekrun-config-YYYYMMDD.json`
+
+```json
+{
+  "version": 1,
+  "exportedAt": "2026-05-12T08:30:00.000Z",
+  "sections": {
+    "recruiter": {
+      "bossRecruiter": { },
+      "candidateFilter": { }
+    },
+    "jobs": { },
+    "llm": { },
+    "webhook": { },
+    "session": {
+      "cookies": [],
+      "localStorage": {}
+    }
+  }
+}
+```
+
+- `session` 仅在用户勾选时写入 bundle
+- `llm.providers[*].apiKey` 在用户不勾选"包含 API Key"时替换为字符串 `"__REDACTED__"`
+- 导入时跳过值为 `"__REDACTED__"` 的字段，保留本地现有值
+
+---
+
+## UI 设计
+
+### 导航入口
+
+`RecruiterPart.vue` 的"集成与工具"分组下新增条目 **"配置管理"**，路由到 `BossConfigManager` 页面。
+
+### 导出区
+
+标题：**导出招聘端配置**
+
+勾选项（默认全选，除"登录会话"外）：
+
+| 勾选项 | 默认 | 说明 |
+|---|---|---|
+| 基础配置（招聘策略 + 候选人筛选） | ✅ | boss-recruiter.json + candidate-filter.json |
+| 职位配置（含 Rubric） | ✅ | boss-jobs-config.json |
+| LLM 配置 | ✅ | boss-llm.json |
+| └ 包含 API Key | ☐ | 子选项，默认关闭 |
+| Webhook 配置 | ✅ | webhook.json |
+| 登录会话（Cookie + localStorage） | ☐ | 默认关闭，显示安全提示 |
+
+按钮：**导出配置文件** → main 端调用 `dialog.showSaveDialog`，写文件到用户选择路径。
+
+### 导入区
+
+标题：**导入配置**
+
+流程：
+1. 拖拽/点击上传区，接受 `.json` 文件
+2. 上传后调用 `preview-recruiter-config-import`（只解析，不写磁盘），返回摘要
+3. UI 展示带勾选的 section 列表（默认全选 bundle 中存在的 section，"登录会话"默认不选）：
+   ```
+   ☑ 基础配置
+   ☑ 职位配置（3 个职位，含 Rubric）
+   ☑ LLM 配置（API Key 已脱敏，导入后需手动补填）
+   ☑ Webhook 配置
+   ☐ 登录会话（含 Cookie，将替换当前登录状态）
+   ```
+4. 显示警告：**导入将覆盖当前对应配置，不可撤销**
+5. 用户调整勾选后点"确认导入"
+
+"确认导入"按钮在文件已选且预览成功后才变为可用。
+
+---
+
+## IPC Handler 设计
+
+新增三个 handler，加入 `packages/ui/src/main/flow/OPEN_SETTING_WINDOW/ipc/index.ts`：
+
+### `export-recruiter-config`
+
+**Payload（renderer → main）：**
+```ts
+{
+  sections: {
+    recruiter?: boolean
+    jobs?: boolean
+    llm?: boolean
+    includeApiKeys?: boolean   // llm 子选项
+    webhook?: boolean
+    session?: boolean
+  }
+}
+```
+
+**流程：**
+1. 根据 `sections` 读取对应配置文件
+2. `llm` 且 `!includeApiKeys` 时，递归将 `apiKey` 字段替换为 `"__REDACTED__"`
+3. 组装 bundle JSON
+4. 调用 `dialog.showSaveDialog`，写文件
+5. 返回 `{ success: boolean, filePath?: string }`
+
+---
+
+### `preview-recruiter-config-import`
+
+**Payload：** `{ bundleJson: string }`
+
+**流程：**
+1. JSON.parse，校验 `version === 1`
+2. 遍历 `sections`，生成摘要：
+   - `recruiter`: 是否存在
+   - `jobs`: 职位数量
+   - `llm`: provider 数量，apiKey 是否脱敏
+   - `webhook`: 是否存在
+   - `session`: 是否存在（标注安全警告）
+3. 不写任何文件
+4. 返回 `{ valid: boolean, summary: SectionSummary[], error?: string }`
+
+---
+
+### `import-recruiter-config`
+
+**Payload：** `{ bundleJson: string, selectedSections: string[] }`
+
+**流程（原子性保证）：**
+1. JSON.parse，校验 `version`
+2. 读取所有 `selectedSections` 对应的现有配置文件到内存（备份）
+3. 逐 section 写入：
+   - `recruiter` → 写 boss-recruiter.json + candidate-filter.json
+   - `jobs` → 写 boss-jobs-config.json
+   - `llm` → 写 boss-llm.json，跳过值为 `"__REDACTED__"` 的 apiKey 字段
+   - `webhook` → 写 webhook.json
+   - `session` → 写 boss-cookies.json + boss-local-storage.json
+4. 任意步骤抛出异常 → 用内存备份回滚所有已写文件
+5. 返回 `{ success: boolean, importedSections: string[], error?: string }`
+
+**UI 响应：**
+- 成功：toast "导入成功，已更新 N 项配置"
+- 失败：toast "导入失败，已还原至原始配置"
+
+---
+
+## 文件变更清单
+
+| 文件 | 变更类型 | 说明 |
+|---|---|---|
+| `packages/ui/src/renderer/src/page/MainLayout/LeftNavBar/RecruiterPart.vue` | 修改 | 新增"配置管理"导航条目 |
+| `packages/ui/src/renderer/src/page/MainLayout/BossConfigManager/index.vue` | 新增 | 配置管理页面（导出区 + 导入区） |
+| `packages/ui/src/main/flow/OPEN_SETTING_WINDOW/ipc/index.ts` | 修改 | 新增三个 IPC handler |
+| `packages/ui/src/renderer/src/router/index.ts`（或类似路由文件） | 修改 | 注册 BossConfigManager 路由 |
+
+---
+
+## 约束
+
+- 不引入新的 npm 依赖（adm-zip 等），纯 JSON + Node.js fs
+- API Key 脱敏仅替换字段值，不删除字段，保持结构完整
+- 导入原子性：回滚粒度为"所有被选中的 section"，部分成功不存在

--- a/packages/ui/src/main/flow/OPEN_SETTING_WINDOW/ipc/index.ts
+++ b/packages/ui/src/main/flow/OPEN_SETTING_WINDOW/ipc/index.ts
@@ -24,8 +24,7 @@ import {
 import { PageReq } from '../../../../common/types/pagination'
 import { pipeWriteRegardlessError } from '../../utils/pipe'
 import { WriteStream } from 'node:fs'
-// eslint-disable-next-line vue/prefer-import-from-vue
-import { hasOwn } from '@vue/shared'
+const hasOwn = (obj: object, key: string) => Object.prototype.hasOwnProperty.call(obj, key)
 import { createLlmConfigWindow, llmConfigWindow } from '../../../window/llmConfigWindow'
 import { createResumeEditorWindow, resumeEditorWindow } from '../../../window/resumeEditorWindow'
 import {
@@ -1149,6 +1148,248 @@ export default function initIpc() {
     return { ok: true }
   })
   // ── end 调试工具 LLM 接口 ──────────────────────────────────────────────────────
+
+  // ── 配置管理：导出 / 预览导入 / 导入 ─────────────────────────────────────────
+
+  ipcMain.handle('export-recruiter-config', async (_, payload: {
+    sections: {
+      recruiter?: boolean
+      jobs?: boolean
+      llm?: boolean
+      includeApiKeys?: boolean
+      webhook?: boolean
+      session?: boolean
+    }
+  }) => {
+    const {
+      readConfigFile: readBossConfigFile,
+      readStorageFile: readBossStorageFile,
+      readBossJobsConfig,
+      readBossLlmConfig
+    } = await import('@geekgeekrun/boss-auto-browse-and-chat/runtime-file-utils.mjs')
+
+    const bundle: any = {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      sections: {}
+    }
+
+    if (payload.sections.recruiter) {
+      bundle.sections.recruiter = {
+        bossRecruiter: readBossConfigFile('boss-recruiter.json'),
+        candidateFilter: readBossConfigFile('candidate-filter.json')
+      }
+    }
+
+    if (payload.sections.jobs) {
+      bundle.sections.jobs = readBossJobsConfig()
+    }
+
+    if (payload.sections.llm) {
+      const llmConfig = readBossLlmConfig()
+      if (!payload.sections.includeApiKeys && Array.isArray(llmConfig.providers)) {
+        llmConfig.providers = llmConfig.providers.map((p: any) => ({ ...p, apiKey: '__REDACTED__' }))
+      }
+      bundle.sections.llm = llmConfig
+    }
+
+    if (payload.sections.webhook) {
+      bundle.sections.webhook = readBossConfigFile('webhook.json') ?? {}
+    }
+
+    if (payload.sections.session) {
+      bundle.sections.session = {
+        cookies: readBossStorageFile('boss-cookies.json'),
+        localStorage: readBossStorageFile('boss-local-storage.json')
+      }
+    }
+
+    const dateStr = new Date().toISOString().slice(0, 10).replace(/-/g, '')
+    const result = await dialog.showSaveDialog({
+      defaultPath: `geekgeekrun-config-${dateStr}.json`,
+      filters: [{ name: 'JSON 配置文件', extensions: ['json'] }]
+    })
+
+    if (result.canceled || !result.filePath) {
+      return { success: false }
+    }
+
+    const fsPromises = await import('node:fs/promises')
+    await fsPromises.writeFile(result.filePath, JSON.stringify(bundle, null, 2), 'utf-8')
+    return { success: true, filePath: result.filePath }
+  })
+
+  ipcMain.handle('preview-recruiter-config-import', async (_, payload: { bundleJson: string }) => {
+    let bundle: any
+    try {
+      bundle = JSON.parse(payload.bundleJson)
+    } catch {
+      return { valid: false, error: '文件解析失败，请确认是有效的 JSON 文件' }
+    }
+
+    if (bundle.version !== 1) {
+      return { valid: false, error: `不支持的配置文件版本: ${bundle.version}` }
+    }
+
+    const sections = bundle.sections || {}
+    const summary: Array<{
+      key: string
+      label: string
+      description: string
+      hasSecurityWarning?: boolean
+      apiKeysRedacted?: boolean
+    }> = []
+
+    if (sections.recruiter) {
+      summary.push({ key: 'recruiter', label: '基础配置', description: '招聘策略 + 候选人筛选条件' })
+    }
+    if (sections.jobs) {
+      const jobCount = (sections.jobs.jobs || []).length
+      summary.push({ key: 'jobs', label: '职位配置', description: `${jobCount} 个职位（含 Rubric）` })
+    }
+    if (sections.llm) {
+      const providerCount = (sections.llm.providers || []).length
+      const hasRedacted = (sections.llm.providers || []).some((p: any) => p.apiKey === '__REDACTED__')
+      summary.push({
+        key: 'llm',
+        label: 'LLM 配置',
+        description: `${providerCount} 个 Provider${hasRedacted ? '（API Key 已脱敏，导入后需手动补填）' : ''}`,
+        apiKeysRedacted: hasRedacted
+      })
+    }
+    if (sections.webhook) {
+      summary.push({ key: 'webhook', label: 'Webhook 配置', description: 'Webhook / 外部集成' })
+    }
+    if (sections.session) {
+      summary.push({
+        key: 'session',
+        label: '登录会话',
+        description: '含 Cookie，导入后将替换当前登录状态',
+        hasSecurityWarning: true
+      })
+    }
+
+    return { valid: true, exportedAt: bundle.exportedAt, summary }
+  })
+
+  ipcMain.handle('import-recruiter-config', async (_, payload: {
+    bundleJson: string
+    selectedSections: string[]
+  }) => {
+    const {
+      readConfigFile: readBossConfigFile,
+      writeConfigFile: writeBossConfigFile,
+      readStorageFile: readBossStorageFile,
+      writeStorageFile: writeBossStorageFile,
+      readBossJobsConfig,
+      writeBossJobsConfig,
+      readBossLlmConfig,
+      writeBossLlmConfig
+    } = await import('@geekgeekrun/boss-auto-browse-and-chat/runtime-file-utils.mjs')
+
+    let bundle: any
+    try {
+      bundle = JSON.parse(payload.bundleJson)
+    } catch {
+      return { success: false, error: '文件解析失败' }
+    }
+
+    if (bundle.version !== 1) {
+      return { success: false, error: `不支持的配置文件版本: ${bundle.version}` }
+    }
+
+    const selected = new Set(payload.selectedSections)
+    const sections = bundle.sections || {}
+
+    // Backup existing configs before writing
+    const backup: Record<string, any> = {}
+    if (selected.has('recruiter') && sections.recruiter) {
+      backup['boss-recruiter.json'] = readBossConfigFile('boss-recruiter.json')
+      backup['candidate-filter.json'] = readBossConfigFile('candidate-filter.json')
+    }
+    if (selected.has('jobs') && sections.jobs) {
+      backup['boss-jobs-config.json'] = readBossJobsConfig()
+    }
+    if (selected.has('llm') && sections.llm) {
+      backup['boss-llm.json'] = readBossLlmConfig()
+    }
+    if (selected.has('webhook') && sections.webhook) {
+      backup['webhook.json'] = readBossConfigFile('webhook.json')
+    }
+    if (selected.has('session') && sections.session) {
+      backup['boss-cookies.json'] = readBossStorageFile('boss-cookies.json')
+      backup['boss-local-storage.json'] = readBossStorageFile('boss-local-storage.json')
+    }
+
+    const written: string[] = []
+    try {
+      if (selected.has('recruiter') && sections.recruiter) {
+        await writeBossConfigFile('boss-recruiter.json', sections.recruiter.bossRecruiter)
+        written.push('boss-recruiter.json')
+        await writeBossConfigFile('candidate-filter.json', sections.recruiter.candidateFilter)
+        written.push('candidate-filter.json')
+      }
+
+      if (selected.has('jobs') && sections.jobs) {
+        await writeBossJobsConfig(sections.jobs)
+        written.push('boss-jobs-config.json')
+      }
+
+      if (selected.has('llm') && sections.llm) {
+        const llmToWrite = JSON.parse(JSON.stringify(sections.llm))
+        if (Array.isArray(llmToWrite.providers)) {
+          const existingProviderMap = new Map(
+            (backup['boss-llm.json']?.providers || []).map((p: any) => [p.id, p])
+          )
+          llmToWrite.providers = llmToWrite.providers.map((p: any) => {
+            if (p.apiKey === '__REDACTED__') {
+              const existing: any = existingProviderMap.get(p.id)
+              return { ...p, apiKey: existing?.apiKey ?? '' }
+            }
+            return p
+          })
+        }
+        await writeBossLlmConfig(llmToWrite)
+        written.push('boss-llm.json')
+      }
+
+      if (selected.has('webhook') && sections.webhook) {
+        await writeBossConfigFile('webhook.json', sections.webhook)
+        written.push('webhook.json')
+      }
+
+      if (selected.has('session') && sections.session) {
+        await writeBossStorageFile('boss-cookies.json', sections.session.cookies)
+        written.push('boss-cookies.json')
+        await writeBossStorageFile('boss-local-storage.json', sections.session.localStorage)
+        written.push('boss-local-storage.json')
+      }
+
+      return { success: true, importedSections: payload.selectedSections }
+    } catch (err: any) {
+      // Rollback all written files
+      try {
+        for (const fileName of written) {
+          if (backup[fileName] !== undefined) {
+            if (fileName === 'boss-cookies.json' || fileName === 'boss-local-storage.json') {
+              await writeBossStorageFile(fileName, backup[fileName])
+            } else if (fileName === 'boss-jobs-config.json') {
+              await writeBossJobsConfig(backup[fileName] ?? { jobs: [] })
+            } else if (fileName === 'boss-llm.json') {
+              await writeBossLlmConfig(backup[fileName])
+            } else {
+              await writeBossConfigFile(fileName, backup[fileName])
+            }
+          }
+        }
+      } catch {
+        // ignore rollback errors
+      }
+      return { success: false, error: err?.message ?? '导入失败，已还原至原始配置' }
+    }
+  })
+
+  // ── end 配置管理 ──────────────────────────────────────────────────────────────
 
   ipcMain.handle('sync-boss-job-list', async (ev) => {
     const { setLevel, debug: logDebug, info: logInfo } = await import(

--- a/packages/ui/src/renderer/src/page/MainLayout/BossConfigManager/index.vue
+++ b/packages/ui/src/renderer/src/page/MainLayout/BossConfigManager/index.vue
@@ -1,0 +1,386 @@
+<template>
+  <div class="boss-config-manager__wrap">
+    <div class="main__wrap">
+      <!-- 导出区 -->
+      <el-card class="config-section">
+        <div class="section-title">导出招聘端配置</div>
+        <p class="section-desc">将当前配置打包为 JSON 文件，可分发给同事导入使用。</p>
+
+        <el-form label-position="top">
+          <el-form-item label="选择要导出的内容">
+            <div class="checkbox-group">
+              <el-checkbox v-model="exportOptions.recruiter">基础配置（招聘策略 + 候选人筛选条件）</el-checkbox>
+              <el-checkbox v-model="exportOptions.jobs">职位配置（含 Rubric）</el-checkbox>
+              <el-checkbox v-model="exportOptions.llm">LLM 配置</el-checkbox>
+              <div v-if="exportOptions.llm" class="sub-checkbox">
+                <el-checkbox v-model="exportOptions.includeApiKeys">
+                  包含 API Key
+                  <el-text type="warning" size="small">（明文导出，注意安全）</el-text>
+                </el-checkbox>
+              </div>
+              <el-checkbox v-model="exportOptions.webhook">Webhook 配置</el-checkbox>
+              <div class="session-checkbox-row">
+                <el-checkbox v-model="exportOptions.session">
+                  登录会话（Cookie + localStorage）
+                </el-checkbox>
+                <el-tag v-if="exportOptions.session" type="danger" size="small" style="margin-left: 8px">
+                  安全风险：含登录凭据
+                </el-tag>
+              </div>
+            </div>
+          </el-form-item>
+
+          <el-form-item>
+            <el-button
+              type="primary"
+              :loading="exporting"
+              :disabled="!hasAnyExportSelected"
+              @click="handleExport"
+            >
+              导出配置文件
+            </el-button>
+          </el-form-item>
+        </el-form>
+      </el-card>
+
+      <!-- 导入区 -->
+      <el-card class="config-section">
+        <div class="section-title">导入配置</div>
+        <p class="section-desc">从之前导出的配置文件中选择性恢复配置，导入操作不可撤销。</p>
+
+        <div
+          class="upload-zone"
+          :class="{ 'is-dragging': isDragging }"
+          @dragover.prevent="isDragging = true"
+          @dragleave="isDragging = false"
+          @drop.prevent="handleFileDrop"
+          @click="triggerFileInput"
+        >
+          <input
+            ref="fileInputRef"
+            type="file"
+            accept=".json"
+            style="display: none"
+            @change="handleFileChange"
+          />
+          <el-icon :size="32" color="#909399"><Upload /></el-icon>
+          <p class="upload-hint">点击或拖入 .json 配置文件</p>
+        </div>
+
+        <!-- 预览区 -->
+        <div v-if="previewState === 'loading'" class="preview-loading">
+          <el-icon class="is-loading"><Loading /></el-icon>
+          <span>正在解析文件...</span>
+        </div>
+
+        <div v-if="previewState === 'error'" class="preview-error">
+          <el-alert :title="previewError" type="error" :closable="false" show-icon />
+        </div>
+
+        <div v-if="previewState === 'ready'" class="preview-ready">
+          <div class="preview-meta">
+            导出时间：{{ formatExportedAt(previewData.exportedAt) }}
+          </div>
+
+          <el-alert
+            title="导入将覆盖当前对应配置，操作不可撤销。"
+            type="warning"
+            :closable="false"
+            show-icon
+            style="margin-bottom: 12px"
+          />
+
+          <div class="import-section-list">
+            <div
+              v-for="item in previewData.summary"
+              :key="item.key"
+              class="import-section-item"
+            >
+              <el-checkbox v-model="importSelected[item.key]">
+                <span class="section-label">{{ item.label }}</span>
+                <span class="section-desc-inline">{{ item.description }}</span>
+              </el-checkbox>
+              <el-tag v-if="item.hasSecurityWarning" type="danger" size="small" style="margin-left: 8px">
+                安全风险
+              </el-tag>
+            </div>
+          </div>
+
+          <el-button
+            type="primary"
+            :loading="importing"
+            :disabled="!hasAnyImportSelected"
+            style="margin-top: 16px"
+            @click="handleImport"
+          >
+            确认导入
+          </el-button>
+        </div>
+      </el-card>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed, reactive } from 'vue'
+import { ElMessage } from 'element-plus'
+import { Upload, Loading } from '@element-plus/icons-vue'
+
+const exportOptions = reactive({
+  recruiter: true,
+  jobs: true,
+  llm: true,
+  includeApiKeys: false,
+  webhook: true,
+  session: false
+})
+
+const exporting = ref(false)
+const hasAnyExportSelected = computed(
+  () => exportOptions.recruiter || exportOptions.jobs || exportOptions.llm || exportOptions.webhook || exportOptions.session
+)
+
+async function handleExport() {
+  exporting.value = true
+  try {
+    const result = await electron.ipcRenderer.invoke('export-recruiter-config', {
+      sections: {
+        recruiter: exportOptions.recruiter,
+        jobs: exportOptions.jobs,
+        llm: exportOptions.llm,
+        includeApiKeys: exportOptions.includeApiKeys,
+        webhook: exportOptions.webhook,
+        session: exportOptions.session
+      }
+    })
+    if (result.success) {
+      ElMessage({ type: 'success', message: `配置已导出：${result.filePath}` })
+    }
+  } catch (err: any) {
+    ElMessage({ type: 'error', message: err?.message ?? '导出失败' })
+  } finally {
+    exporting.value = false
+  }
+}
+
+// Import
+const fileInputRef = ref<HTMLInputElement>()
+const isDragging = ref(false)
+const previewState = ref<'idle' | 'loading' | 'error' | 'ready'>('idle')
+const previewError = ref('')
+const previewData = ref<{
+  exportedAt: string
+  summary: Array<{
+    key: string
+    label: string
+    description: string
+    hasSecurityWarning?: boolean
+    apiKeysRedacted?: boolean
+  }>
+}>({ exportedAt: '', summary: [] })
+const importSelected = reactive<Record<string, boolean>>({})
+const bundleJson = ref('')
+const importing = ref(false)
+
+const hasAnyImportSelected = computed(
+  () => Object.values(importSelected).some(Boolean)
+)
+
+function triggerFileInput() {
+  fileInputRef.value?.click()
+}
+
+function handleFileDrop(e: DragEvent) {
+  isDragging.value = false
+  const file = e.dataTransfer?.files?.[0]
+  if (file) loadFile(file)
+}
+
+function handleFileChange(e: Event) {
+  const file = (e.target as HTMLInputElement).files?.[0]
+  if (file) loadFile(file)
+}
+
+function loadFile(file: File) {
+  const reader = new FileReader()
+  reader.onload = async (e) => {
+    const text = e.target?.result as string
+    bundleJson.value = text
+    await runPreview(text)
+  }
+  reader.readAsText(file)
+}
+
+async function runPreview(json: string) {
+  previewState.value = 'loading'
+  try {
+    const result = await electron.ipcRenderer.invoke('preview-recruiter-config-import', { bundleJson: json })
+    if (!result.valid) {
+      previewState.value = 'error'
+      previewError.value = result.error ?? '文件无效'
+      return
+    }
+    previewData.value = result
+    // default: select all except session
+    const newSelected: Record<string, boolean> = {}
+    for (const item of result.summary) {
+      newSelected[item.key] = item.key !== 'session'
+    }
+    Object.assign(importSelected, newSelected)
+    previewState.value = 'ready'
+  } catch (err: any) {
+    previewState.value = 'error'
+    previewError.value = err?.message ?? '预览失败'
+  }
+}
+
+async function handleImport() {
+  importing.value = true
+  try {
+    const selectedSections = Object.entries(importSelected)
+      .filter(([, v]) => v)
+      .map(([k]) => k)
+    const result = await electron.ipcRenderer.invoke('import-recruiter-config', {
+      bundleJson: bundleJson.value,
+      selectedSections
+    })
+    if (result.success) {
+      ElMessage({ type: 'success', message: `导入成功，已更新 ${result.importedSections.length} 项配置` })
+      previewState.value = 'idle'
+      bundleJson.value = ''
+      if (fileInputRef.value) fileInputRef.value.value = ''
+    } else {
+      ElMessage({ type: 'error', message: result.error ?? '导入失败，已还原至原始配置' })
+    }
+  } catch (err: any) {
+    ElMessage({ type: 'error', message: err?.message ?? '导入失败' })
+  } finally {
+    importing.value = false
+  }
+}
+
+function formatExportedAt(iso: string) {
+  if (!iso) return '未知'
+  try {
+    return new Date(iso).toLocaleString('zh-CN')
+  } catch {
+    return iso
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.boss-config-manager__wrap {
+  height: 100%;
+  overflow-y: auto;
+}
+
+.main__wrap {
+  padding: 20px;
+  max-width: 700px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.config-section {
+  .section-title {
+    font-size: 16px;
+    font-weight: 600;
+    margin-bottom: 8px;
+  }
+
+  .section-desc {
+    color: var(--el-text-color-secondary);
+    font-size: 13px;
+    margin-bottom: 16px;
+    margin-top: 0;
+  }
+}
+
+.checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sub-checkbox {
+  padding-left: 24px;
+}
+
+.session-checkbox-row {
+  display: flex;
+  align-items: center;
+}
+
+.upload-zone {
+  border: 2px dashed var(--el-border-color);
+  border-radius: 8px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: border-color 0.2s;
+
+  &:hover,
+  &.is-dragging {
+    border-color: var(--el-color-primary);
+    background: var(--el-color-primary-light-9);
+  }
+
+  .upload-hint {
+    color: var(--el-text-color-secondary);
+    font-size: 13px;
+    margin: 0;
+  }
+}
+
+.preview-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 0;
+  color: var(--el-text-color-secondary);
+}
+
+.preview-error {
+  margin-top: 12px;
+}
+
+.preview-ready {
+  margin-top: 16px;
+
+  .preview-meta {
+    font-size: 13px;
+    color: var(--el-text-color-secondary);
+    margin-bottom: 12px;
+  }
+}
+
+.import-section-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid var(--el-border-color-lighter);
+  border-radius: 6px;
+  padding: 12px 16px;
+  background: var(--el-fill-color-lighter);
+}
+
+.import-section-item {
+  display: flex;
+  align-items: center;
+
+  .section-label {
+    font-weight: 500;
+  }
+
+  .section-desc-inline {
+    color: var(--el-text-color-secondary);
+    font-size: 12px;
+    margin-left: 6px;
+  }
+}
+</style>

--- a/packages/ui/src/renderer/src/page/MainLayout/LeftNavBar/RecruiterPart.vue
+++ b/packages/ui/src/renderer/src/page/MainLayout/LeftNavBar/RecruiterPart.vue
@@ -37,6 +37,9 @@
       <RouterLink :to="{ name: 'BossDebugTool' }">
         调试与测试工具
       </RouterLink>
+      <RouterLink :to="{ name: 'BossConfigManager' }">
+        配置管理
+      </RouterLink>
 
     </div>
   </div>

--- a/packages/ui/src/renderer/src/router/index.ts
+++ b/packages/ui/src/renderer/src/router/index.ts
@@ -185,6 +185,14 @@ const routes: Array<RouteRecordRaw> = [
         meta: {
           title: '招聘端大语言模型配置'
         }
+      },
+      {
+        name: 'BossConfigManager',
+        path: 'BossConfigManager',
+        component: () => import('@renderer/page/MainLayout/BossConfigManager/index.vue'),
+        meta: {
+          title: '配置管理'
+        }
       }
     ]
   },


### PR DESCRIPTION
## Summary

- 在左导航「集成与工具」下新增**配置管理**入口（`BossConfigManager` 页面）
- 支持将招聘端所有配置打包为单个 `.json` 文件**导出**，可选择哪些 section 导出（基础配置、职位配置含 Rubric、LLM 配置含 API Key 可选脱敏、Webhook、登录会话）
- 支持从导出文件中**选择性原子导入**：上传后先预览摘要+勾选 section，确认后写入；任意 section 写入失败则自动回滚所有已写文件
- 新增 3 个 IPC handler：`export-recruiter-config` / `preview-recruiter-config-import` / `import-recruiter-config`

## Test plan

- [ ] 在「配置管理」页面勾选各 section 后点导出，确认弹出保存对话框且文件内容正确
- [ ] 不勾选「包含 API Key」时，导出 JSON 中 `providers[*].apiKey` 值为 `__REDACTED__`
- [ ] 将导出文件上传，确认预览摘要显示正确（职位数量、API Key 脱敏提示等）
- [ ] 取消勾选部分 section 后导入，确认只有选中的 section 被写入
- [ ] 模拟导入中途失败，确认现有配置未被更改（原子性验证）
- [ ] 登录会话 section 默认不勾选，勾选后显示安全警告标签

🤖 Generated with [Claude Code](https://claude.com/claude-code)