### PR TITLE
feat: import and send resume image after greeting

### DIFF
--- a/packages/geek-auto-start-chat-with-boss/default-config-file/boss.json
+++ b/packages/geek-auto-start-chat-with-boss/default-config-file/boss.json
@@ -40,5 +40,7 @@
   "sageTimeOpTimes": 100,
   "sageTimePauseMinute": 15,
   "blockCompanyNameRegExpStr": "",
-  "fieldsForUseCommonConfig": {}
+  "fieldsForUseCommonConfig": {},
+  "sendResumeImageAfterGreeting": false,
+  "resumeImagePath": ""
 }

--- a/packages/geek-auto-start-chat-with-boss/index.mjs
+++ b/packages/geek-auto-start-chat-with-boss/index.mjs
@@ -300,6 +300,11 @@ const blockCompanyNameRegExp = (() => {
   }
 })()
 const blockCompanyNameRegMatchStrategy = readConfigFile('boss.json').blockCompanyNameRegMatchStrategy ?? MarkAsNotSuitOp.NO_OP
+const resumeImageConfig = readConfigFile('boss.json')
+const sendResumeImageAfterGreeting = resumeImageConfig.sendResumeImageAfterGreeting === true
+const resumeImagePath = typeof resumeImageConfig.resumeImagePath === 'string'
+  ? resumeImageConfig.resumeImagePath.trim()
+  : ''
 
 /**
  * @type { import('puppeteer').Browser }
@@ -313,6 +318,241 @@ let page
 const blockBossNotNewChat = new Set()
 const blockBossNotActive = new Set()
 const blockJobNotSuit = new Set()
+
+const chatImageInputSelectors = [
+  '.toolbar-btn-content.icon.btn-sendimg input[type="file"]',
+  '[class*="sendimg"] input[type="file"]',
+  '.chat-conversation .message-controls input[type="file"]',
+  'input[type="file"][accept*="image"]'
+]
+const chatImageTriggerSelectors = [
+  '.toolbar-btn-content.icon.btn-sendimg',
+  '[class*="sendimg"]',
+  '.chat-conversation .message-controls [class*="upload"]'
+]
+
+const sentImageSelectors = [
+  // The current BOSS chat UI marks outgoing bubbles with `.item-myself`.
+  // Keep the older selectors too, because BOSS ships its chat DOM gradually.
+  '.item-myself img',
+  '.item-myself [class*="image"] img',
+  '.chat-message .message-item.is-self img',
+  '.chat-message .message-item-self img',
+  '.chat-list .message-item.is-self img',
+  '.chat-list .message-item-self img'
+]
+const bossChatUiUrl = 'https://www.zhipin.com/web/geek/chat'
+
+function normaliseChatUrl (value) {
+  if (typeof value !== 'string' || !value.trim()) {
+    return ''
+  }
+  try {
+    const url = new URL(value, 'https://www.zhipin.com')
+    return url.pathname.includes('/geek/chat') ? url.href : ''
+  } catch {
+    return ''
+  }
+}
+
+function findChatUrlDeep (value, seen = new Set()) {
+  if (typeof value === 'string') {
+    return normaliseChatUrl(value)
+  }
+  if (!value || typeof value !== 'object' || seen.has(value)) {
+    return ''
+  }
+  seen.add(value)
+  for (const item of Object.values(value)) {
+    const chatUrl = findChatUrlDeep(item, seen)
+    if (chatUrl) {
+      return chatUrl
+    }
+  }
+  return ''
+}
+
+async function getChatUrlFromStartChatButton (startChatButtonProxy) {
+  const rawUrl = await startChatButtonProxy.evaluate((el) => {
+    return el.getAttribute('redirect-url') ||
+      el.dataset.redirectUrl ||
+      el.getAttribute('href') ||
+      el.getAttribute('data-url') ||
+      el.dataset.url ||
+      ''
+  })
+  return normaliseChatUrl(rawUrl)
+}
+
+async function findChatImageInput (chatPage) {
+  const findExistingInput = async () => {
+    for (const selector of chatImageInputSelectors) {
+      const input = await chatPage.$(selector)
+      if (input) {
+        return input
+      }
+    }
+    return null
+  }
+
+  const existingInput = await findExistingInput()
+  if (existingInput) {
+    return existingInput
+  }
+
+  // BOSS may not mount its hidden file input until the image toolbar action is opened.
+  for (const selector of chatImageTriggerSelectors) {
+    const trigger = await chatPage.$(selector)
+    if (trigger) {
+      await trigger.click().catch(() => void 0)
+      break
+    }
+  }
+  try {
+    await chatPage.waitForFunction((selectors) => {
+      return selectors.some((selector) => document.querySelector(selector))
+    }, { timeout: 5000 }, chatImageInputSelectors)
+    return await findExistingInput()
+  } catch {
+    return null
+  }
+}
+
+async function selectGreetedConversation (chatPage, targetJobData) {
+  const encryptJobId = targetJobData?.jobInfo?.encryptId
+  if (!encryptJobId) {
+    throw new Error('missing job ID for chat conversation selection')
+  }
+
+  await chatPage.waitForFunction(() => {
+    return Array.isArray(document.querySelector('.main-wrap .chat-user')?.__vue__?.list)
+  }, { timeout: 30000 })
+
+  let conversationIndex = -1
+  const deadline = Date.now() + 8000
+  while (Date.now() < deadline && conversationIndex < 0) {
+    conversationIndex = await chatPage.evaluate((jobId) => {
+      const list = document.querySelector('.main-wrap .chat-user')?.__vue__?.list ?? []
+      return list.findIndex((item) => item.encryptJobId === jobId)
+    }, encryptJobId)
+    if (conversationIndex < 0) {
+      await sleep(250)
+    }
+  }
+  if (conversationIndex < 0) {
+    throw new Error(`greeted conversation was not found for job ${encryptJobId}`)
+  }
+
+  await chatPage.evaluate((index) => {
+    document.querySelector('.chat-content .user-list .user-list-content')?.__vue__?.scrollToIndex(index)
+  }, conversationIndex)
+  await sleep(400)
+  const conversationItem = (await chatPage.evaluateHandle((jobId) => {
+    const items = document.querySelectorAll('.main-wrap .chat-user .user-list-content ul[role=group] li[role=listitem]')
+    return [...items].find((item) => item.__vue__?.source?.encryptJobId === jobId) ?? null
+  }, encryptJobId)).asElement()
+  if (!conversationItem) {
+    throw new Error(`greeted conversation element was not rendered for job ${encryptJobId}`)
+  }
+  await Promise.all([
+    chatPage.waitForResponse((response) => response.url().startsWith('https://www.zhipin.com/wapi/zpchat/geek/historyMsg'), { timeout: 30000 }),
+    conversationItem.click()
+  ])
+}
+
+async function sendResumeImageInTemporaryChat (chatUrl, targetJobData) {
+  if (!sendResumeImageAfterGreeting) {
+    return
+  }
+  if (!fs.existsSync(resumeImagePath)) {
+    console.warn('[resume-image] skipped: configured image does not exist', {
+      resumeImagePath,
+      jobId: targetJobData?.jobInfo?.encryptId,
+      bossId: targetJobData?.jobInfo?.encryptUserId
+    })
+    return
+  }
+  let chatPage
+  try {
+    chatPage = await browser.newPage()
+    // Keep this short-lived page visible while it selects the conversation and uploads the image.
+    // The search page is restored in finally without navigating it away from its current job list.
+    await chatPage.bringToFront()
+    await chatPage.goto(chatUrl || bossChatUiUrl, { waitUntil: 'domcontentloaded', timeout: 30000 })
+    if (!normaliseChatUrl(chatPage.url())) {
+      throw new Error(`unexpected chat page URL: ${chatPage.url()}`)
+    }
+    if (!chatUrl) {
+      console.log('[resume-image] no direct chat URL; selecting the greeted conversation from the chat list', {
+        jobId: targetJobData?.jobInfo?.encryptId,
+        bossId: targetJobData?.jobInfo?.encryptUserId
+      })
+      await selectGreetedConversation(chatPage, targetJobData)
+    }
+
+    const beforeImageCount = await chatPage.evaluate((selectors) => {
+      return selectors.reduce((count, selector) => count + document.querySelectorAll(selector).length, 0)
+    }, sentImageSelectors)
+    const fileInput = await findChatImageInput(chatPage)
+    if (!fileInput) {
+      throw new Error('chat image file input was not found')
+    }
+
+    await fileInput.uploadFile(resumeImagePath)
+    // Puppeteer's uploadFile uses CDP DOM.setFileInputFiles. Unlike a user file
+    // selection, that API does not dispatch DOM events, so BOSS never starts its
+    // image-upload handler unless we explicitly emit them.
+    await fileInput.evaluate((input) => {
+      input.dispatchEvent(new Event('input', { bubbles: true, composed: true }))
+      input.dispatchEvent(new Event('change', { bubbles: true }))
+    })
+
+    const confirmationDeadline = Date.now() + 8000
+    let confirmed = false
+    let fileConsumed = false
+    while (Date.now() < confirmationDeadline) {
+      await sleep(250)
+      const state = await chatPage.evaluate((inputSelectors, selectors) => {
+        const input = inputSelectors
+          .map((selector) => document.querySelector(selector))
+          .find(Boolean)
+        return {
+          fileConsumed: !input?.files || input.files.length === 0,
+          sentImageCount: selectors.reduce((count, selector) => count + document.querySelectorAll(selector).length, 0)
+        }
+      }, chatImageInputSelectors, sentImageSelectors).catch(() => ({ fileConsumed: false, sentImageCount: beforeImageCount }))
+      fileConsumed = fileConsumed || state.fileConsumed
+      // Clearing the file input only means that the UI accepted the selection.
+      // Do not close the temporary page until the outgoing image bubble exists:
+      // closing earlier cancels BOSS's asynchronous upload request.
+      if (state.sentImageCount > beforeImageCount) {
+        confirmed = true
+        break
+      }
+    }
+    if (confirmed) {
+      console.log('[resume-image] sent after greeting', {
+        jobId: targetJobData?.jobInfo?.encryptId,
+        bossId: targetJobData?.jobInfo?.encryptUserId
+      })
+    } else {
+      console.warn('[resume-image] upload was not confirmed before the temporary chat closed; it will not be retried', {
+        jobId: targetJobData?.jobInfo?.encryptId,
+        bossId: targetJobData?.jobInfo?.encryptUserId,
+        fileConsumed
+      })
+    }
+  } catch (err) {
+    console.warn('[resume-image] failed after greeting; continuing search flow', {
+      jobId: targetJobData?.jobInfo?.encryptId,
+      bossId: targetJobData?.jobInfo?.encryptUserId,
+      error: err instanceof Error ? err.message : String(err)
+    })
+  } finally {
+    await chatPage?.close().catch(() => void 0)
+    await page?.bringToFront().catch(() => void 0)
+  }
+}
 
 async function markJobAsNotSuitInRecommendPage (reasonCode) {
   /**
@@ -1522,6 +1762,9 @@ async function toRecommendPage (hooks) {
 
           await hooks.newChatWillStartup?.promise(targetJobData)
           const startChatButtonProxy = await page.$('.job-detail-box .op-btn.op-btn-chat')
+          const chatUrlFromStartButton = startChatButtonProxy
+            ? await getChatUrlFromStartChatButton(startChatButtonProxy)
+            : ''
           await sleep(500)
           //#region click the chat button
           await startChatButtonProxy.click()
@@ -1553,7 +1796,7 @@ async function toRecommendPage (hooks) {
               }
             }
           }
-          const waitAndHandleChatSuccess = async ({ hasGoToChatPage = false } = {}) => {
+          const waitAndHandleChatSuccess = async ({ hasGoToChatPage = false, chatUrl = '' } = {}) => {
             await hooks.newChatStartup?.promise(
               targetJobData,
               {
@@ -1577,10 +1820,14 @@ async function toRecommendPage (hooks) {
               await closeDialogButtonProxy.click()
               await sleepWithRandomDelay(2000)
             }
+            await sendResumeImageInTemporaryChat(chatUrl, targetJobData)
           }
           const handleAddFriendResponse = async (res, { hasGoToChatPage = false } = {}) => {
             if (res.code === 0) {
-              await waitAndHandleChatSuccess({ hasGoToChatPage })
+              await waitAndHandleChatSuccess({
+                hasGoToChatPage,
+                chatUrl: chatUrlFromStartButton || findChatUrlDeep(res)
+              })
             }
             else if (
               res.zpData.bizCode === 1 &&

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,6 +31,7 @@
     "@geekgeekrun/puppeteer-extra-plugin-laodeng": "workspace:*",
     "@geekgeekrun/sqlite-plugin": "workspace:*",
     "@geekgeekrun/utils": "workspace:*",
+    "@napi-rs/canvas": "^0.1.77",
     "JSONStream": "^1.3.5",
     "diff": "^7.0.0",
     "electron-updater": "^6.1.7",
@@ -40,6 +41,7 @@
     "node-machine-id": "^1.1.12",
     "pinia": "^3.0.2",
     "puppeteer": "24.19.0",
+    "pdfjs-dist": "^4.10.38",
     "puppeteer-extra-plugin-stealth": "2.11.2",
     "uuid": "^11.1.0",
     "vuedraggable": "^4.1.0"

--- a/packages/ui/src/main/features/resume-image-import/index.ts
+++ b/packages/ui/src/main/features/resume-image-import/index.ts
@@ -1,0 +1,225 @@
+import { app } from 'electron'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+const execFileAsync = promisify(execFile)
+const require = createRequire(import.meta.url)
+const supportedExtensionSet = new Set(['.doc', '.docx', '.pdf', '.jpg', '.jpeg', '.png'])
+const wordExtensionSet = new Set(['.doc', '.docx'])
+const jpegExtensionSet = new Set(['.jpg', '.jpeg'])
+
+export type ResumeImageImportResult = {
+  resumeImagePath: string
+  pageCount: number
+}
+
+type Canvas = {
+  width: number
+  height: number
+  getContext: (contextId: '2d') => CanvasRenderingContext
+  encode: (format: 'jpeg', quality: number) => Promise<Uint8Array>
+}
+
+type CanvasRenderingContext = {
+  fillStyle: string
+  fillRect: (x: number, y: number, width: number, height: number) => void
+  drawImage: (image: Canvas | LoadedImage, dx: number, dy: number) => void
+}
+
+type LoadedImage = {
+  width: number
+  height: number
+}
+
+type PdfPage = {
+  getViewport: (options: { scale: number }) => { width: number; height: number }
+  render: (options: {
+    canvasContext: CanvasRenderingContext
+    viewport: { width: number; height: number }
+  }) => { promise: Promise<void> }
+}
+
+type PdfDocument = {
+  numPages: number
+  getPage: (pageNumber: number) => Promise<PdfPage>
+  destroy: () => Promise<void>
+}
+
+function getStandardFontDataUrl() {
+  const packageRoot = path.dirname(require.resolve('pdfjs-dist/package.json'))
+  return pathToFileURL(path.join(packageRoot, 'standard_fonts') + path.sep).href
+}
+
+function getResumeImageFolderPath() {
+  return path.join(app.getPath('home'), '.geekgeekrun', 'resume-images')
+}
+
+function getOutputFilePath() {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  return path.join(getResumeImageFolderPath(), `resume-${stamp}.jpg`)
+}
+
+async function assertReadableFile(filePath: string) {
+  const stat = await fs.stat(filePath)
+  if (!stat.isFile()) {
+    throw new Error('请选择一个文件，而不是文件夹。')
+  }
+  if (!stat.size) {
+    throw new Error('简历文件为空，无法导入。')
+  }
+}
+
+async function convertWordToPdf(sourcePath: string, tempFolderPath: string) {
+  const outputPath = path.join(tempFolderPath, 'resume.pdf')
+  const script = `
+$ErrorActionPreference = 'Stop'
+$word = $null
+$document = $null
+try {
+  $word = New-Object -ComObject Word.Application
+  $word.Visible = $false
+  $word.DisplayAlerts = 0
+  $document = $word.Documents.Open($env:GEEKGEEKRUN_RESUME_SOURCE, $false, $true)
+  $document.ExportAsFixedFormat($env:GEEKGEEKRUN_RESUME_PDF, 17)
+} finally {
+  if ($document -ne $null) { $document.Close($false) }
+  if ($word -ne $null) { $word.Quit() }
+}
+`
+  try {
+    await execFileAsync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', script],
+      {
+        windowsHide: true,
+        timeout: 90_000,
+        env: {
+          ...process.env,
+          GEEKGEEKRUN_RESUME_SOURCE: sourcePath,
+          GEEKGEEKRUN_RESUME_PDF: outputPath
+        }
+      }
+    )
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(`Word 转换失败。请确认已安装 Microsoft Word，且文件未受密码保护。${detail}`)
+  }
+  await assertReadableFile(outputPath)
+  return outputPath
+}
+
+async function renderPdfToJpeg(sourcePath: string, outputPath: string) {
+  const [canvasPackage, pdfjs] = await Promise.all([
+    import('@napi-rs/canvas'),
+    import('pdfjs-dist/legacy/build/pdf.mjs')
+  ])
+  const { createCanvas } = canvasPackage as unknown as {
+    createCanvas: (width: number, height: number) => Canvas
+  }
+  const data = new Uint8Array(await fs.readFile(sourcePath))
+  const document = await (
+    pdfjs as {
+      getDocument: (options: {
+        data: Uint8Array
+        disableWorker: boolean
+        standardFontDataUrl: string
+        verbosity: number
+      }) => {
+        promise: Promise<PdfDocument>
+      }
+    }
+  ).getDocument({
+    data,
+    disableWorker: true,
+    standardFontDataUrl: getStandardFontDataUrl(),
+    // Avoid emitting non-fatal PDF.js warnings through Electron's stdout pipe.
+    verbosity: 0
+  }).promise
+  if (!document.numPages) {
+    throw new Error('PDF 中没有可转换的页面。')
+  }
+
+  const pages: Array<{ canvas: Canvas; width: number; height: number }> = []
+  const scale = 1.5
+  for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+    const page = await document.getPage(pageNumber)
+    const viewport = page.getViewport({ scale })
+    const canvas = createCanvas(Math.ceil(viewport.width), Math.ceil(viewport.height))
+    const context = canvas.getContext('2d')
+    context.fillStyle = '#ffffff'
+    context.fillRect(0, 0, canvas.width, canvas.height)
+    await page.render({ canvasContext: context, viewport }).promise
+    pages.push({ canvas, width: canvas.width, height: canvas.height })
+  }
+  await document.destroy()
+
+  const width = Math.max(...pages.map((page) => page.width))
+  const height = pages.reduce((total, page) => total + page.height, 0)
+  const outputCanvas = createCanvas(width, height)
+  const outputContext = outputCanvas.getContext('2d')
+  outputContext.fillStyle = '#ffffff'
+  outputContext.fillRect(0, 0, width, height)
+  let offsetY = 0
+  for (const page of pages) {
+    outputContext.drawImage(page.canvas, Math.floor((width - page.width) / 2), offsetY)
+    offsetY += page.height
+  }
+  await fs.writeFile(outputPath, await outputCanvas.encode('jpeg', 90))
+  return pages.length
+}
+
+async function convertPngToJpeg(sourcePath: string, outputPath: string) {
+  const canvasPackage = await import('@napi-rs/canvas')
+  const { createCanvas, loadImage } = canvasPackage as unknown as {
+    createCanvas: (width: number, height: number) => Canvas
+    loadImage: (source: string) => Promise<LoadedImage>
+  }
+  const image = await loadImage(sourcePath)
+  if (!image.width || !image.height) {
+    throw new Error('PNG 图片尺寸无效，无法导入。')
+  }
+  const canvas = createCanvas(image.width, image.height)
+  const context = canvas.getContext('2d')
+  context.fillStyle = '#ffffff'
+  context.fillRect(0, 0, canvas.width, canvas.height)
+  context.drawImage(image, 0, 0)
+  await fs.writeFile(outputPath, await canvas.encode('jpeg', 90))
+}
+
+export async function importResumeImage(sourcePath: string): Promise<ResumeImageImportResult> {
+  const extension = path.extname(sourcePath).toLowerCase()
+  if (!supportedExtensionSet.has(extension)) {
+    throw new Error('仅支持 Word、PDF、JPG、JPEG 和 PNG 格式的简历。')
+  }
+  await assertReadableFile(sourcePath)
+  await fs.mkdir(getResumeImageFolderPath(), { recursive: true })
+  const outputPath = getOutputFilePath()
+  const tempFolderPath = await fs.mkdtemp(path.join(app.getPath('temp'), 'geekgeekrun-resume-'))
+
+  try {
+    if (jpegExtensionSet.has(extension)) {
+      await fs.copyFile(sourcePath, outputPath)
+      return { resumeImagePath: outputPath, pageCount: 1 }
+    }
+    if (extension === '.png') {
+      await convertPngToJpeg(sourcePath, outputPath)
+      return { resumeImagePath: outputPath, pageCount: 1 }
+    }
+    const pdfPath = wordExtensionSet.has(extension)
+      ? await convertWordToPdf(sourcePath, tempFolderPath)
+      : sourcePath
+    return {
+      resumeImagePath: outputPath,
+      pageCount: await renderPdfToJpeg(pdfPath, outputPath)
+    }
+  } catch (error) {
+    await fs.rm(outputPath, { force: true }).catch(() => undefined)
+    throw error
+  } finally {
+    await fs.rm(tempFolderPath, { recursive: true, force: true }).catch(() => undefined)
+  }
+}

--- a/packages/ui/src/main/features/run-common.ts
+++ b/packages/ui/src/main/features/run-common.ts
@@ -3,7 +3,13 @@ import { daemonEE, sendToDaemon } from '../flow/OPEN_SETTING_WINDOW/connect-to-d
 import { saveAndGetCurrentRunRecord } from '../flow/OPEN_SETTING_WINDOW/utils/db'
 import minimist from 'minimist'
 
-export async function runCommon({ mode }) {
+export async function runCommon({
+  mode,
+  restartIfRunning = false
+}: {
+  mode: string
+  restartIfRunning?: boolean
+}) {
   await sendToDaemon(
     {
       type: 'user-process-register'
@@ -24,12 +30,34 @@ export async function runCommon({ mode }) {
   )?.workers
   const runningTask = taskList?.find((it) => it.workerId === mode)
   if (runningTask) {
-    const commandlineArgs = minimist(runningTask.args ?? [])
-    const runRecordId = Number(commandlineArgs['run-record-id'])
-    console.log('任务已在运行中')
-    return {
-      runRecordId,
-      isAlreadyRunning: true
+    if (restartIfRunning) {
+      const workerExited = new Promise<void>((resolve) => {
+        daemonEE.on('message', function handler(message) {
+          if (message.type !== 'worker-exited' || message.workerId !== mode) {
+            return
+          }
+          daemonEE.off('message', handler)
+          resolve()
+        })
+      })
+      await sendToDaemon(
+        {
+          type: 'stop-worker',
+          workerId: mode
+        },
+        {
+          needCallback: true
+        }
+      )
+      await workerExited
+    } else {
+      const commandlineArgs = minimist(runningTask.args ?? [])
+      const runRecordId = Number(commandlineArgs['run-record-id'])
+      console.log('任务已在运行中')
+      return {
+        runRecordId,
+        isAlreadyRunning: true
+      }
     }
   }
   const currentRunRecord = (await saveAndGetCurrentRunRecord())?.data

--- a/packages/ui/src/main/flow/OPEN_SETTING_WINDOW/ipc/index.ts
+++ b/packages/ui/src/main/flow/OPEN_SETTING_WINDOW/ipc/index.ts
@@ -58,8 +58,30 @@ import {
 import { getLastUsedAndAvailableBrowser } from '../../DOWNLOAD_DEPENDENCIES/utils/browser-history'
 import { waitForCommonJobConditionDone } from '../../../features/common-job-condition'
 import { ensureConfigFileExist } from '@geekgeekrun/geek-auto-start-chat-with-boss/runtime-file-utils.mjs'
+import { importResumeImage } from '../../../features/resume-image-import'
 
 export default function initIpc() {
+  ipcMain.handle('import-resume-image', async (ev) => {
+    const win = BrowserWindow.fromWebContents(ev.sender)
+    const result = await dialog.showOpenDialog(win ?? undefined, {
+      title: '导入简历',
+      properties: ['openFile'],
+      filters: [
+        { name: '简历文件', extensions: ['doc', 'docx', 'pdf', 'jpg', 'jpeg', 'png'] }
+      ]
+    })
+    if (result.canceled || !result.filePaths?.[0]) {
+      return { canceled: true }
+    }
+
+    const imported = await importResumeImage(result.filePaths[0])
+    ensureConfigFileExist()
+    const bossConfig = readConfigFile('boss.json')
+    bossConfig.resumeImagePath = imported.resumeImagePath
+    await writeConfigFile('boss.json', bossConfig)
+    return { canceled: false, ...imported }
+  })
+
   ipcMain.handle('save-config-file-from-ui', async (ev, payload) => {
     payload = JSON.parse(payload)
     ensureConfigFileExist()
@@ -174,6 +196,12 @@ export default function initIpc() {
     }
     if (hasOwn(payload, 'fieldsForUseCommonConfig')) {
       bossConfig.fieldsForUseCommonConfig = payload.fieldsForUseCommonConfig
+    }
+    if (hasOwn(payload, 'resumeImagePath')) {
+      bossConfig.resumeImagePath = payload.resumeImagePath
+    }
+    if (hasOwn(payload, 'sendResumeImageAfterGreeting')) {
+      bossConfig.sendResumeImageAfterGreeting = payload.sendResumeImageAfterGreeting === true
     }
 
     promiseArr.push(writeConfigFile('boss.json', bossConfig))

--- a/packages/ui/src/main/flow/OPEN_SETTING_WINDOW/ipc/index.ts
+++ b/packages/ui/src/main/flow/OPEN_SETTING_WINDOW/ipc/index.ts
@@ -215,19 +215,25 @@ export default function initIpc() {
     return await Promise.all(promiseArr)
   })
 
-  ipcMain.handle('run-geek-auto-start-chat-with-boss', async (ev) => {
-    const mode = 'geekAutoStartWithBossMain'
-    const { runRecordId } = await runCommon({ mode })
-    daemonEE.on('message', function handler(message) {
-      if (message.workerId !== mode) {
-        return
-      }
-      if (message.type === 'worker-exited') {
-        mainWindow?.webContents.send('worker-exited', message)
-      }
-    })
-    return { runRecordId }
-  })
+  ipcMain.handle(
+    'run-geek-auto-start-chat-with-boss',
+    async (_ev, options: { restartIfRunning?: boolean } = {}) => {
+      const mode = 'geekAutoStartWithBossMain'
+      const { runRecordId } = await runCommon({
+        mode,
+        restartIfRunning: options.restartIfRunning === true
+      })
+      daemonEE.on('message', function handler(message) {
+        if (message.workerId !== mode) {
+          return
+        }
+        if (message.type === 'worker-exited') {
+          mainWindow?.webContents.send('worker-exited', message)
+        }
+      })
+      return { runRecordId }
+    }
+  )
 
   ipcMain.handle('run-read-no-reply-auto-reminder', async () => {
     const mode = 'readNoReplyAutoReminderMain'

--- a/packages/ui/src/renderer/src/page/MainLayout/GeekAutoStartChatWithBoss/index.vue
+++ b/packages/ui/src/renderer/src/page/MainLayout/GeekAutoStartChatWithBoss/index.vue
@@ -2192,7 +2192,8 @@ const handleSubmit = async () => {
   try {
     runningOverlayRef.value?.show()
     const { runRecordId: rrId } = await electron.ipcRenderer.invoke(
-      'run-geek-auto-start-chat-with-boss'
+      'run-geek-auto-start-chat-with-boss',
+      { restartIfRunning: true }
     )
     runRecordId.value = rrId
   } catch (err) {

--- a/packages/ui/src/renderer/src/page/MainLayout/GeekAutoStartChatWithBoss/index.vue
+++ b/packages/ui/src/renderer/src/page/MainLayout/GeekAutoStartChatWithBoss/index.vue
@@ -1655,6 +1655,26 @@
               </div>
             </div>
           </el-card>
+          <el-card class="config-section">
+            <div font-size-16px mb8px>简历图片</div>
+            <div font-size-12px lh-1.6em mb12px style="color: #666">
+              导入 Word、PDF、JPG 或 PNG 简历。Word/PDF 多页会合成为一张长图；导入后的图片由应用保存，原文件可以移动或删除。
+            </div>
+            <div flex items-center gap12px flex-wrap>
+              <el-button :loading="isResumeImporting" @click="handleImportResumeImage">
+                导入简历
+              </el-button>
+              <el-checkbox v-model="formContent.sendResumeImageAfterGreeting">
+                打招呼后发送简历图片
+              </el-checkbox>
+            </div>
+            <div mt10px font-size-12px break-all style="color: #666">
+              <template v-if="formContent.resumeImagePath">
+                当前简历图片：{{ formContent.resumeImagePath }}
+              </template>
+              <template v-else>尚未导入简历图片</template>
+            </div>
+          </el-card>
         </el-form>
       </div>
       <div class="bg-#f8f8f8 pb10px pt10px">
@@ -1814,7 +1834,9 @@ const formContent = ref({
   sageTimePauseMinute: 15,
   blockCompanyNameRegExpStr: '',
   blockCompanyNameRegMatchStrategy: MarkAsNotSuitOp.NO_OP,
-  fieldsForUseCommonConfig: {}
+  fieldsForUseCommonConfig: {},
+  resumeImagePath: '',
+  sendResumeImageAfterGreeting: false
 })
 
 const anyCombineBossRecommendFilterHasCondition = computed(() => {
@@ -1978,6 +2000,9 @@ electron.ipcRenderer.invoke('fetch-config-file-content').then((res) => {
     res.config['boss.json'].blockCompanyNameRegMatchStrategy ?? MarkAsNotSuitOp.NO_OP
   formContent.value.fieldsForUseCommonConfig =
     res.config['boss.json']?.fieldsForUseCommonConfig ?? {}
+  formContent.value.resumeImagePath = res.config['boss.json']?.resumeImagePath ?? ''
+  formContent.value.sendResumeImageAfterGreeting =
+    res.config['boss.json']?.sendResumeImageAfterGreeting === true
 
   commonJobConditionConfig.value = {
     expectJobNameRegExpStr:
@@ -2083,6 +2108,7 @@ const formRules = {
 }
 
 const formRef = ref<InstanceType<typeof ElForm>>()
+const isResumeImporting = ref(false)
 const runRecordId = ref(null)
 const runningOverlayRef = ref(null)
 const taskManagerStore = useTaskManagerStore()
@@ -2102,6 +2128,29 @@ onMounted(async () => {
     }
   }
 })
+
+const handleImportResumeImage = async () => {
+  if (isResumeImporting.value) {
+    return
+  }
+  isResumeImporting.value = true
+  try {
+    const result = await electron.ipcRenderer.invoke('import-resume-image')
+    if (result?.canceled) {
+      return
+    }
+    formContent.value.resumeImagePath = result.resumeImagePath
+    ElMessage.success(`简历导入成功，已生成 ${result.pageCount} 页合成图片`)
+    gtagRenderer('resume_image_imported', { page_count: result.pageCount })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error('导入简历失败', error)
+    ElMessage.error({ message: `导入简历失败：${message}`, grouping: true })
+    gtagRenderer('resume_image_import_failed', { message })
+  } finally {
+    isResumeImporting.value = false
+  }
+}
 
 const handleSubmit = async () => {
   gtagRenderer('save_config_and_launch_clicked', {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@geekgeekrun/utils':
         specifier: workspace:*
         version: link:../utils
+      '@napi-rs/canvas':
+        specifier: ^0.1.77
+        version: 0.1.100
       JSONStream:
         specifier: ^1.3.5
         version: 1.3.5
@@ -195,6 +198,9 @@ importers:
       node-machine-id:
         specifier: ^1.1.12
         version: 1.1.12
+      pdfjs-dist:
+        specifier: ^4.10.38
+        version: 4.10.38
       pinia:
         specifier: ^3.0.2
         version: 3.0.2(typescript@5.3.3)(vue@3.4.15)
@@ -1411,6 +1417,122 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@napi-rs/canvas-android-arm64@0.1.100:
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-darwin-arm64@0.1.100:
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-darwin-x64@0.1.100:
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-arm-gnueabihf@0.1.100:
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-arm64-gnu@0.1.100:
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-arm64-musl@0.1.100:
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-riscv64-gnu@0.1.100:
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-x64-gnu@0.1.100:
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-x64-musl@0.1.100:
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-win32-arm64-msvc@0.1.100:
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-win32-x64-msvc@0.1.100:
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas@0.1.100:
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    dev: false
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -5540,6 +5662,13 @@ packages:
   /pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
     dev: true
+
+  /pdfjs-dist@4.10.38:
+    resolution: {integrity: sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==}
+    engines: {node: '>=20'}
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
+    dev: false
 
   /pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}


### PR DESCRIPTION
## Summary

- Adds an opt-in `sendResumeImageAfterGreeting` setting. It is disabled by default.
- Adds a UI import flow for JPG/JPEG, PNG, PDF, DOC, and DOCX resumes. Imported files are copied or converted into an application-managed JPEG under the current user's `.geekgeekrun/resume-images` directory.
- PDF pages are rendered and merged into one JPEG before upload. DOC/DOCX import requires Microsoft Word on Windows; on other platforms, users can import a PDF or image.

## Behaviour and safety

- The default configuration uses `sendResumeImageAfterGreeting: false` and an empty `resumeImagePath`, so existing users keep the previous greeting/search behaviour until they explicitly import a resume and enable the option.
- Only after a successful greeting response does the core flow open a short-lived BOSS chat page and call Puppeteer's image upload API. The search page remains in place.
- Upload, conversation-selection, and confirmation errors are caught locally. The temporary page is closed and the search page is restored, so an image-send failure is logged without stopping the job loop.
- No machine-specific resume path is shipped.

## Dependency notes

- `@napi-rs/canvas` is used only in the Electron main process for the Canvas API required by PDF.js rendering and PNG-to-JPEG conversion. It provides optional prebuilt platform binaries and avoids a separate system graphics installation.
- PDF.js is configured with its packaged standard-font directory and quiet logging so non-fatal font warnings do not surface as Electron main-process errors.

## Validation

- Ran `node --check packages/geek-auto-start-chat-with-boss/index.mjs`.
- Ran ESLint for `src/main/features/resume-image-import/index.ts`.
- Completed an Electron smoke test using the actual import module: JPG, PNG, PDF, DOCX, and DOC fixtures all produced a JPEG; an unsupported file was rejected. The DOC/DOCX portion used Microsoft Word COM on Windows.
- Completed a production Electron UI build with `electron-vite build`.
- Checked the configuration and control-flow boundaries: the default option bypasses image sending; the enabled call is placed after the successful greeting branch; and the uploader catches failures before control returns to the search loop.

The smoke test does not contact BOSS or send an image to a real recruiter. A live end-to-end upload was intentionally not run because it would create an external message.
