### PR TITLE
feat: 支持求职类型（全职/兼职/实习）筛选并适配日薪薪资格式

### DIFF
--- a/packages/geek-auto-start-chat-with-boss/combineCalculator.mjs
+++ b/packages/geek-auto-start-chat-with-boss/combineCalculator.mjs
@@ -160,7 +160,8 @@ export function formatStaticCombineFilters(rawStaticCombineRecommendJobFilterCon
       experienceList: condition.experience ? [condition.experience] : [],
       degreeList: condition.degree ? [condition.degree] : [],
       scaleList: condition.scale ? [condition.scale] : [],
-      industryList: condition.industry ? [condition.industry] : []
+      industryList: condition.industry ? [condition.industry] : [],
+      jobTypeList: condition.jobType ? [condition.jobType] : []
     }
   })
   if (!result.length) {
@@ -170,7 +171,8 @@ export function formatStaticCombineFilters(rawStaticCombineRecommendJobFilterCon
       experienceList: [],
       degreeList: [],
       scaleList: [],
-      industryList: []
+      industryList: [],
+      jobTypeList: []
     })
   }
   return result

--- a/packages/geek-auto-start-chat-with-boss/default-config-file/boss.json
+++ b/packages/geek-auto-start-chat-with-boss/default-config-file/boss.json
@@ -6,7 +6,8 @@
     "experienceList": [],
     "degreeList": [],
     "scaleList": [],
-    "industryList": []
+    "industryList": [],
+    "jobTypeList": []
   },
   "staticCombineRecommendJobFilterConditions": [],
   "isSkipEmptyConditionForCombineRecommendJobFilter": false,

--- a/packages/geek-auto-start-chat-with-boss/index.mjs
+++ b/packages/geek-auto-start-chat-with-boss/index.mjs
@@ -489,12 +489,13 @@ async function setFilterCondition (selectedFilters) {
     experienceList = [],
     degreeList = [],
     scaleList = [],
-    industryList = []
+    industryList = [],
+    jobTypeList = []
   } = selectedFilters
 
-  const placeholderTexts = ['城市', '薪资待遇', '工作经验', '学历要求', '公司行业', '公司规模']
-  const optionKaPrefixes = ['switch_city_dialog_open', 'sel-job-rec-salary-', 'sel-job-rec-exp-', 'sel-job-rec-degree-', 'sel-industry-', 'sel-job-rec-scale-']
-  const conditionArr = [cityList, salaryList, experienceList, degreeList, industryList, scaleList]
+  const placeholderTexts = ['城市', '求职类型', '薪资待遇', '工作经验', '学历要求', '公司行业', '公司规模']
+  const optionKaPrefixes = ['switch_city_dialog_open', 'sel-job-rec-jobtype-', 'sel-job-rec-salary-', 'sel-job-rec-exp-', 'sel-job-rec-degree-', 'sel-industry-', 'sel-job-rec-scale-']
+  const conditionArr = [cityList, jobTypeList, salaryList, experienceList, degreeList, industryList, scaleList]
 
   console.log('current filter condition----')
   for (let i = 0; i < placeholderTexts.length; i++) {
@@ -596,8 +597,16 @@ async function setFilterCondition (selectedFilters) {
             }
           } else {
             // select 不限 immediately
-            const buxianOptionElProxy = await page.$(`.page-jobs-main .filter-condition-inner [ka="${optionKaPrefix}${0}"]`)
-            await buxianOptionElProxy.click()
+            let buxianOptionElProxy = await page.$(`.page-jobs-main .filter-condition-inner [ka="${optionKaPrefix}${0}"]`)
+            if (!buxianOptionElProxy && placeholderText === '求职类型') {
+              buxianOptionElProxy = await page.evaluateHandle((dropdownEl) => {
+                const items = dropdownEl.querySelectorAll('ul li, a, div')
+                return Array.from(items).find(el => el.textContent.trim() === '不限')
+              }, filterDropdownProxy).then(h => h.asElement())
+            }
+            if (buxianOptionElProxy) {
+              await buxianOptionElProxy.click()
+            }
           }
         } else {
           //#region uncheck options perviously checked but not existed in current filter.
@@ -647,11 +656,24 @@ async function setFilterCondition (selectedFilters) {
               filterDropdownElBBox.y + filterDropdownElBBox.height / 2,
             )
             await sleepWithRandomDelay(500)
-            const optionElProxy = await page.$(`.page-jobs-main .filter-condition-inner [ka="${optionKaPrefix}${optionValue}"]`)
+            let optionElProxy = await page.$(`.page-jobs-main .filter-condition-inner [ka="${optionKaPrefix}${optionValue}"]`)
+            if (!optionElProxy && placeholderText === '求职类型') {
+              const textMap = { '0': '不限', '1': '全职', '2': '兼职', '3': '实习' }
+              const targetText = textMap[optionValue]
+              if (targetText) {
+                optionElProxy = await page.evaluateHandle((dropdownEl, text) => {
+                  const items = dropdownEl.querySelectorAll('ul li, a, div')
+                  return Array.from(items).find(el => el.textContent.trim() === text)
+                }, filterDropdownProxy, targetText).then(h => h.asElement())
+              }
+            }
             if (!optionElProxy) {
               continue;
             }
-            await optionElProxy.click()
+            const isOptionAlreadyActive = await optionElProxy.evaluate(el => el.classList.contains('active'))
+            if (!isOptionAlreadyActive) {
+              await optionElProxy.click()
+            }
           }
           //#endregion
           //#region move out dropdown entry to make dropdown hidden
@@ -828,6 +850,9 @@ async function toRecommendPage (hooks) {
     iterateFilterCondition: for (
       const filterCondition of filterConditions
     ) {
+      if (filterCondition.jobTypeList === undefined) {
+        filterCondition.jobTypeList = anyCombineRecommendJobFilter.jobTypeList || []
+      }
       filterConditionIndex++
       console.log(`current filter condition index to apply: ${filterConditionIndex}`, JSON.stringify(filterCondition))
       findInCurrentFilterCondition: while(true) {
@@ -950,6 +975,9 @@ async function toRecommendPage (hooks) {
 
                 // skip invalid salaryData (兼职、日结、实习 etc)
                 jobListData.forEach(it => {
+                  if (it.salaryDesc && (it.salaryDesc.includes('天') || it.salaryDesc.includes('日'))) {
+                    return
+                  }
                   const salaryData = parseSalary(it.salaryDesc)
                   if (!salaryData.high || !salaryData.low) {
                     blockJobNotSuit.add(it.encryptJobId)

--- a/packages/ui/src/renderer/src/features/AnyCombineBossRecommendFilter/index.vue
+++ b/packages/ui/src/renderer/src/features/AnyCombineBossRecommendFilter/index.vue
@@ -126,6 +126,18 @@
         />
       </el-select>
     </div>
+    <div class="filter-item">
+      <div font-size-12px>求职类型</div>
+      <el-select
+        v-model="modelValue.jobTypeList"
+        multiple
+        clearable
+        collapse-tags
+        collapse-tags-tooltip
+      >
+        <el-option v-for="it in jobTypeOptions" :key="it.code" :value="it.code" :label="it.name" />
+      </el-select>
+    </div>
   </div>
 </template>
 
@@ -135,14 +147,22 @@ import industryFilterExemption from '@geekgeekrun/geek-auto-start-chat-with-boss
 import CityChooser from '@renderer/page/MainLayout/GeekAutoStartChatWithBoss/components/CityChooser.vue'
 import { PropType } from 'vue'
 
+const jobTypeOptions = [
+  { code: 1, name: '全职' },
+  { code: 2, name: '兼职' },
+  { code: 3, name: '实习' }
+]
+
 defineProps({
   modelValue: {
     type: Object as PropType<{
+      cityList: string[]
       salaryList: number[]
       experienceList: number[]
       degreeList: number[]
       industryList: number[]
       scaleList: number[]
+      jobTypeList: number[]
     }>
   }
 })

--- a/packages/ui/src/renderer/src/features/StaticCombineBossRecommendFilter/index.vue
+++ b/packages/ui/src/renderer/src/features/StaticCombineBossRecommendFilter/index.vue
@@ -141,6 +141,23 @@
             </el-select>
           </template>
         </el-table-column>
+        <el-table-column :resizable="false" label="求职类型" prop="jobType">
+          <template #default="{ row }">
+            <el-select
+              v-model="row.jobType"
+              :disabled="row.___itemType === 'empty-condition-placeholder'"
+              clearable
+              size="small"
+            >
+              <el-option
+                v-for="it in jobTypeOptions"
+                :key="it.code"
+                :value="it.code"
+                :label="it.name"
+              />
+            </el-select>
+          </template>
+        </el-table-column>
         <el-table-column :resizable="false" label="公司行业" :width="200" prop="industry">
           <template #default="{ row }">
             <el-select
@@ -206,6 +223,12 @@ import CityChooser from '@renderer/page/MainLayout/GeekAutoStartChatWithBoss/com
 
 import { getStaticCombineFilterKey } from '@geekgeekrun/geek-auto-start-chat-with-boss/combineCalculator.mjs'
 
+const jobTypeOptions = [
+  { code: 1, name: '全职' },
+  { code: 2, name: '兼职' },
+  { code: 3, name: '实习' }
+]
+
 const props = defineProps({
   modelValue: {
     type: Array as PropType<
@@ -215,6 +238,7 @@ const props = defineProps({
         degree: number | null
         industry: number | null
         scale: number | null
+        jobType: number | null
       }>
     >,
     default: () => []
@@ -238,7 +262,8 @@ function getNewConditionItem() {
     experience: null,
     degree: null,
     industry: null,
-    scale: null
+    scale: null,
+    jobType: null
   }
 }
 

--- a/packages/ui/src/renderer/src/page/MainLayout/GeekAutoStartChatWithBoss/index.vue
+++ b/packages/ui/src/renderer/src/page/MainLayout/GeekAutoStartChatWithBoss/index.vue
@@ -1869,7 +1869,11 @@ electron.ipcRenderer.invoke('fetch-config-file-content').then((res) => {
     experienceList: [],
     degreeList: [],
     scaleList: [],
-    industryList: []
+    industryList: [],
+    jobTypeList: []
+  }
+  if (!formContent.value.anyCombineRecommendJobFilter.jobTypeList) {
+    formContent.value.anyCombineRecommendJobFilter.jobTypeList = []
   }
   unwatchAnyCombineRecommendJobFilter.value = watch(
     () => formContent.value?.anyCombineRecommendJobFilter,


### PR DESCRIPTION
为使用此项目找实习的人: 
新增工作类型字段 , 不勾选则为原来的逻辑
<img width="1124" height="400" alt="image" src="https://github.com/user-attachments/assets/21e3599d-4f6f-4cad-863b-b9a3e650e9f1" />


<img width="877" height="255" alt="image" src="https://github.com/user-attachments/assets/9017d981-3d6b-4190-a6b1-34082843396d" />

ps: 实习岗位薪资以NULL填充, 避免与正职引起混淆

<img width="887" height="142" alt="image" src="https://github.com/user-attachments/assets/e85e3f68-25a2-4d8f-b22f-b0a0e6d5b363" />
